### PR TITLE
Put 'backtrace' usage behind feature to not require nightly

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,10 @@ license-file = "LICENSE"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[features]
+default = []
+backtrace = []
+
 [dependencies]
 futures-util = "0.3"
 lazy_static = "1.4"


### PR DESCRIPTION
Fixes https://github.com/slickbench/tower-opentelemetry/issues/2

Also, ran `cargo fmt`.